### PR TITLE
Check whether content object has 'getExcludeFromNav' method.

### DIFF
--- a/ftw/mobilenavigation/browser/navigation.py
+++ b/ftw/mobilenavigation/browser/navigation.py
@@ -32,8 +32,9 @@ class UpdateMobileNavigation(BrowserView):
         for brain in parent.getFolderContents():
             if brain.portal_type not in hidden_types:
                 obj = brain.getObject()
-                if not obj.getExcludeFromNav():
-                    objs.append(obj)
+                if hasattr(obj, 'getExcludeFromNav'):
+                    if not obj.getExcludeFromNav():
+                        objs.append(obj)
         return objs
 
     def get_css_classes(self, obj):


### PR DESCRIPTION
Not all objects have the 'getExcludeFromNav' method. For example, dexterity types use a behavior for that (for which you probably have to add a check too once dexterity lands in the core).
