### PR TITLE
Use fallback for old android browsers.

### DIFF
--- a/ftw/mobilenavigation/browser/resources/navigation.js
+++ b/ftw/mobilenavigation/browser/resources/navigation.js
@@ -38,23 +38,36 @@ function load_navi_buttons(section) {
   });
 }
 
+function is_mobile() {
+  if (window.matchMedia == undefined) {
+    if (screen.width <= 767) {
+      return true;
+    }
+    return false;
+  }
+  else if (window.matchMedia("(max-width: 767px)").matches) {
+    return true;
+  }
+  return false;
+}
+
 function initialize_mobile_navi() {
-  if (!$.browser.msie) {
-    var body = $("body");
-    if (window.matchMedia("(max-width: 767px)").matches) {
-      if (!body.hasClass('mobileNaviLoaded')) {
-        // load globalnav buttons
-        load_children($('#toggle_navigation'), $('#portal-globalnav'));
-        load_navi_buttons($('#portal-globalnav.mobileNavigation'));
-        body.addClass('mobileNaviLoaded');
-      }
-      else {
-        $('#portal-globalnav').addClass('mobileNavigation');
-      }
+  var body = $("body");
+
+  if (is_mobile()) {
+    if (!body.hasClass('mobileNaviLoaded')) {
+      // load globalnav buttons
+      load_children($('#toggle_navigation'), $('#portal-globalnav'));
+      load_navi_buttons($('#portal-globalnav.mobileNavigation'));
+      body.addClass('mobileNaviLoaded');
     }
     else {
-      $('#portal-globalnav').removeClass('mobileNavigation');
+      $('#portal-globalnav').addClass('mobileNavigation');
     }
+  }
+  else {
+    // if the browser is resized bigger than 767 px
+    $('#portal-globalnav').removeClass('mobileNavigation');
   }
 }
 


### PR DESCRIPTION
Check if there is a js function 'matchMedia'. If not, check the devices screen size to decide if the mobile navigation should be loaded.
=> fixed problems in old mobile browsers (android < 3, opera mini, ...)
