### PR TITLE
Fixed condition to show dexterity objects.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed condition to show dexterity objects.
+  Also check index for Missing.Value.
+  [Julian Infanger]
 
 
 1.1.1 (2013-06-05)

--- a/ftw/mobilenavigation/browser/navigation.py
+++ b/ftw/mobilenavigation/browser/navigation.py
@@ -1,3 +1,4 @@
+import Missing
 from Products.CMFCore.utils import getToolByName
 from zope.publisher.browser import BrowserView
 
@@ -31,7 +32,7 @@ class UpdateMobileNavigation(BrowserView):
         hidden_types = properties.navtree_properties.metaTypesNotToList
         for brain in parent.getFolderContents():
             if brain.portal_type not in hidden_types:
-                if getattr(brain, 'exclude_from_nav', False) is False:
+                if getattr(brain, 'exclude_from_nav', False) in [Missing.Value, False]:
                     obj = brain.getObject()
                     objs.append(obj)
         return objs

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(name='ftw.mobilenavigation',
 
       install_requires=[
         'setuptools',
+        'Missing',
         ],
       tests_require=tests_require,
       extras_require=dict(tests=tests_require),


### PR DESCRIPTION
Also check index for `Missing.Value`. @lukasgraf we talked about that...
