### PR TITLE
Workaround for wrong classes on navigation elements after resizing the w...

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed class lost after resizing on tabs
+  [Kevin Bieri]
 
 
 1.3.0 (2014-06-02)

--- a/ftw/mobilenavigation/browser/resources/expand_navigation.js
+++ b/ftw/mobilenavigation/browser/resources/expand_navigation.js
@@ -1,5 +1,6 @@
 function load_children(element, parent) {
   var level = 0;
+
   if (parent.hasClass('level0')) {level = 1;}
   if (parent.hasClass('level1')) {level = 2;}
   if (parent.hasClass('level2')) {level = 3;}
@@ -22,6 +23,12 @@ function load_children(element, parent) {
         load_navi_buttons(result);
         if (level === 0) {
           parent.replaceWith(result);
+
+          var lis = result.find('li');
+          parent.find('li').each(function(i, o){
+            lis.eq(i).addClass($(o).attr('class'));
+          });
+
         }
         else {
           parent.removeClass('loading');


### PR DESCRIPTION
For responsive behavior this package generates new tree for mobile navigation. After resizing to normal width the elements lost their classes which marked the selected element. So I made a workaround that applies the old classes to the new generated elements from the server.
