### PR TITLE
Add title when description is not present

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -16,6 +16,10 @@ Changelog
 - Replace doubled code in plonetheme.onegov
   [Kevin Bieri]
 
+- Add title to mobilebutton when description is not present.
+  For accessibility reasons, title attribute on element can't be empty.
+  [Kevin Bieri]
+
 
 1.3.1 (2014-10-24)
 ------------------

--- a/ftw/mobilenavigation/viewlets/buttons.pt
+++ b/ftw/mobilenavigation/viewlets/buttons.pt
@@ -2,7 +2,7 @@
     <li tal:repeat="button view/buttons">
       <a tal:attributes="id button/extra/id;
                          href button/action;
-                         title button/description;
+                         title python: button.get('description') or button.get('title');
                          target button/target|nothing">
         <span class="hiddenStructure"
               tal:content="button/title"


### PR DESCRIPTION
When description is not present title attribute is empty so it no longer
valid for accessiblity.