### PR TITLE
Load spinner relative to site root.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Load spinner relative to site root.
+  This fixes a BadRequest when in portal_factory.
+  [jone]
 
 
 1.4.0 (2015-02-24)

--- a/ftw/mobilenavigation/browser/resources/expand_navigation.js
+++ b/ftw/mobilenavigation/browser/resources/expand_navigation.js
@@ -101,7 +101,7 @@ function is_mobile() {
 function initialize_mobile_navi() {
   var body = $("body");
   spinner = new Image();
-  spinner.src = '++resource++ftw.mobilenavigation/spinner.gif';
+  spinner.src = portal_url + '/++resource++ftw.mobilenavigation/spinner.gif';
   spinner.id = 'spinner-preload';
   spinner.onload = function() {
     if (is_mobile()) {


### PR DESCRIPTION
This fixes a BadRequest when in portal_factory.

@maethu 