### PR TITLE
Add support for Plone 5.1

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -1,4 +1,4 @@
 [buildout]
 extends =
-    test-plone-4.3.x.cfg
+    test-plone-5.1.x.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.4.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for Plone 5.1. [mbaechtold]
 
 
 1.4.7 (2017-07-11)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,8 @@ Changelog
 1.4.8 (unreleased)
 ------------------
 
+- Drop support for Plone 4.2. [mbaechtold]
+
 - Add support for Plone 5.1. [mbaechtold]
 
 

--- a/ftw/mobilenavigation/testing.py
+++ b/ftw/mobilenavigation/testing.py
@@ -1,3 +1,4 @@
+from ftw.testing import IS_PLONE_5
 from plone.app.testing import applyProfile
 from plone.app.testing import IntegrationTesting, FunctionalTesting
 from plone.app.testing import login
@@ -12,17 +13,21 @@ class MobileNavigationLayer(PloneSandboxLayer):
     defaultBases = (PLONE_FIXTURE,)
 
     def setUpZope(self, app, configurationContext):
-        # Load ZCML
-
-        import ftw.mobilenavigation
-        xmlconfig.file('configure.zcml',
-                       ftw.mobilenavigation,
-                       context=configurationContext)
+        xmlconfig.string(
+            '<configure xmlns="http://namespaces.zope.org/zope">'
+            '  <include package="z3c.autoinclude" file="meta.zcml" />'
+            '  <includePlugins package="plone" />'
+            '  <includePluginsOverrides package="plone" />'
+            '</configure>',
+            context=configurationContext)
 
     def setUpPloneSite(self, portal):
         login(portal, TEST_USER_NAME)
         # Install into Plone site using portal_setup
         applyProfile(portal, 'ftw.mobilenavigation:default')
+
+        if IS_PLONE_5:
+            applyProfile(portal, 'plone.app.contenttypes:default')
 
 
 MOBILE_NAVIGATION_TAGS_FIXTURE = MobileNavigationLayer()

--- a/ftw/mobilenavigation/utils.py
+++ b/ftw/mobilenavigation/utils.py
@@ -1,0 +1,4 @@
+import pkg_resources
+
+
+IS_PLONE_5 = pkg_resources.get_distribution('Products.CMFPlone').version >= '5'

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(name='ftw.mobilenavigation',
 
       classifiers=[
         'Framework :: Plone',
-        'Framework :: Plone :: 4.2',
         'Framework :: Plone :: 4.3',
         'Framework :: Plone :: 5.1',
         'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ maintainer = 'Julian Infanger'
 
 tests_require = [
     'ftw.testing',
+    'plone.app.contenttypes',
     'plone.app.testing',
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ setup(name='ftw.mobilenavigation',
 
       classifiers=[
         'Framework :: Plone',
-        'Framework :: Plone :: 4.1',
         'Framework :: Plone :: 4.2',
         'Framework :: Plone :: 4.3',
+        'Framework :: Plone :: 5.1',
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Python Modules',
         ],

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -1,6 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
-    sources.cfg
-
-package-name = ftw.mobilenavigation

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -1,0 +1,6 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.1.x.cfg
+    sources.cfg
+
+package-name = ftw.mobilenavigation


### PR DESCRIPTION
🚧 DO NOT REVIEW. DO NOT MERGE. WORK IN PROGRESS. 🚧

Open tasks:

- [ ] Fix installation of `ftw.mobilenavigation` (causes some exceptions).
- [ ] Fix "uninstall profile" tests
- [ ] Is `actions.xml` in Plone 5.1 still supported?